### PR TITLE
Omnia/release/#68 migrate nova filters

### DIFF
--- a/src/Filters/Filters.php
+++ b/src/Filters/Filters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tipoff\Schediling\Filters;
+namespace Tipoff\Scheduling\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;

--- a/src/Filters/GameFilters.php
+++ b/src/Filters/GameFilters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tipoff\Schediling\Filters;
+namespace Tipoff\Scheduling\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
 

--- a/src/Models/Game.php
+++ b/src/Models/Game.php
@@ -6,7 +6,7 @@ namespace Tipoff\Scheduling\Models;
 
 use Carbon\Carbon;
 use Illuminate\Support\Str;
-use Tipoff\Schediling\Filters\GameFilters;
+use Tipoff\Scheduling\Filters\GameFilters;
 use Tipoff\Support\Models\BaseModel;
 use Tipoff\Support\Traits\HasPackageFactory;
 use Tipoff\Support\Traits\HasUpdater;

--- a/src/Nova/Filters/FutureSlots.php
+++ b/src/Nova/Filters/FutureSlots.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Nova\Filters;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Laravel\Nova\Filters\BooleanFilter;
+
+class FutureSlots extends BooleanFilter
+{
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(Request $request, $query, $value)
+    {
+        if ($value['future'] == true && $value['past'] == true) {
+            return $query;
+        }
+
+        if ($value['future'] == true) {
+            return $query->where('start_at', '>', Carbon::now());
+        }
+
+        if ($value['past'] == true) {
+            return $query->where('start_at', '<', Carbon::now());
+        }
+
+        return $query;
+    }
+
+    /**
+     * Get the filter's available options.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function options(Request $request)
+    {
+        return [
+            'Future' => 'future',
+            'Past' => 'past',
+        ];
+    }
+
+    public function default()
+    {
+        return [
+            'future' => true,
+            'past' => false,
+        ];
+    }
+}

--- a/src/Nova/Filters/FutureSlots.php
+++ b/src/Nova/Filters/FutureSlots.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace App\Nova\Filters;
+declare(strict_types=1);
+
+namespace Tipoff\Scheduling\Nova\Filters;
 
 use Carbon\Carbon;
 use Illuminate\Http\Request;

--- a/src/Nova/Filters/SlotDayFilter.php
+++ b/src/Nova/Filters/SlotDayFilter.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace App\Nova\Filters;
+declare(strict_types=1);
+
+namespace Tipoff\Scheduling\Nova\Filters;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;

--- a/src/Nova/Filters/SlotDayFilter.php
+++ b/src/Nova/Filters/SlotDayFilter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Nova\Filters;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Laravel\Nova\Filters\DateFilter;
+
+class SlotDayFilter extends DateFilter
+{
+    /**
+     * The displayable name of the filter.
+     *
+     * @var string
+     */
+    public $name = 'Game Date';
+
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(Request $request, $query, $value)
+    {
+        return $query
+            ->join('slots', 'slots.id', 'slot_id')
+            ->where('slots.date', Carbon::parse($value));
+    }
+}

--- a/src/Nova/Filters/SlotRoom.php
+++ b/src/Nova/Filters/SlotRoom.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace App\Nova\Filters;
+declare(strict_types=1);
+
+namespace Tipoff\Scheduling\Nova\Filters;
 
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
@@ -44,7 +46,7 @@ class SlotRoom extends Filter
      */
     public function options(Request $request)
     {
-        $models = \App\Models\Room::all();
+        $models = \Tipoff\EscapeRoom\Models\Room::all();
 
         return $models->pluck('id', 'name')->all();
     }

--- a/src/Nova/Filters/SlotRoom.php
+++ b/src/Nova/Filters/SlotRoom.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tipoff\Scheduling\Nova\Filters;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
 
@@ -46,8 +47,9 @@ class SlotRoom extends Filter
      */
     public function options(Request $request)
     {
-        $models = \Tipoff\EscapeRoom\Models\Room::all();
+        /** @var Model $models */
+        $roomModel = app('room');
 
-        return $models->pluck('id', 'name')->all();
+        return $roomModel->pluck('id', 'name')->all();
     }
 }

--- a/src/Nova/Filters/SlotRoom.php
+++ b/src/Nova/Filters/SlotRoom.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Nova\Filters;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Filters\Filter;
+
+class SlotRoom extends Filter
+{
+    /**
+     * The filter's component.
+     *
+     * @var string
+     */
+    public $component = 'select-filter';
+
+    /**
+     * The displayable name of the filter.
+     *
+     * @var string
+     */
+    public $name = 'Room';
+
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(Request $request, $query, $value)
+    {
+        return $query->whereHas('slot', function ($query) use ($value) {
+            $query->where('slots.room_id', $value);
+        });
+    }
+
+    /**
+     * Get the filter's available options.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function options(Request $request)
+    {
+        $models = \App\Models\Room::all();
+
+        return $models->pluck('id', 'name')->all();
+    }
+}

--- a/src/Nova/Filters/SlotRoomLocation.php
+++ b/src/Nova/Filters/SlotRoomLocation.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace App\Nova\Filters;
+declare(strict_types=1);
+
+namespace Tipoff\Scheduling\Nova\Filters;
 
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
@@ -46,6 +48,6 @@ class SlotRoomLocation extends Filter
      */
     public function options(Request $request)
     {
-        return \App\Models\Location::pluck('id', 'name');
+        return \Tipoff\Locations\Models\Location::pluck('id', 'name');
     }
 }

--- a/src/Nova/Filters/SlotRoomLocation.php
+++ b/src/Nova/Filters/SlotRoomLocation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tipoff\Scheduling\Nova\Filters;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
 
@@ -26,9 +27,8 @@ class SlotRoomLocation extends Filter
     /**
      * Apply the filter to the given query.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  mixed  $value
+     * @param \Illuminate\Http\Request $request
+     * @param mixed $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function apply(Request $request, $query, $value)
@@ -36,8 +36,7 @@ class SlotRoomLocation extends Filter
         return $query
             ->join('slots', 'slots.id', 'slot_id')
             ->join('rooms', 'rooms.id', 'slots.room_id')
-            ->where('rooms.location_id', $value)
-            ->get();
+            ->where('rooms.location_id', $value);
     }
 
     /**
@@ -48,6 +47,9 @@ class SlotRoomLocation extends Filter
      */
     public function options(Request $request)
     {
-        return \Tipoff\Locations\Models\Location::pluck('id', 'name');
+        /** @var Model $locationModel */
+        $locationModel = app('location');
+
+        return $locationModel::pluck('id', 'name');
     }
 }

--- a/src/Nova/Filters/SlotRoomLocation.php
+++ b/src/Nova/Filters/SlotRoomLocation.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Nova\Filters;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Filters\Filter;
+
+class SlotRoomLocation extends Filter
+{
+    /**
+     * The filter's component.
+     *
+     * @var string
+     */
+    public $component = 'select-filter';
+
+    /**
+     * The displayable name of the filter.
+     *
+     * @var string
+     */
+    public $name = 'Location';
+
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(Request $request, $query, $value)
+    {
+        return $query
+            ->join('slots', 'slots.id', 'slot_id')
+            ->join('rooms', 'rooms.id', 'slots.room_id')
+            ->where('rooms.location_id', $value)
+            ->get();
+    }
+
+    /**
+     * Get the filter's available options.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function options(Request $request)
+    {
+        return \App\Models\Location::pluck('id', 'name');
+    }
+}


### PR DESCRIPTION
closes #32

Issue:
Nova/Filters/SlotRoomLocation apply() method, docblock return type

> The declared return type 'Illuminate\Database\Eloquent\Builder' for Tipoff\Scheduling\Nova\Filters\SlotRoomLocation::apply is incorrect, got 'Illuminate\Database\Eloquent\Collection|array<array-key, Illuminate\Database\Eloquent\Builder&static>'

> The inferred type 'Illuminate\Database\Eloquent\Collection|array<array-key, Illuminate\Database\Eloquent\Builder&static>' does not match the declared return type 'Illuminate\Database\Eloquent\Builder' for Tipoff\Scheduling\Nova\Filters\SlotRoomLocation::apply